### PR TITLE
Updating dokuwiki docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
-FROM alpine:3.3
+FROM alpine:3.6
 MAINTAINER Jérémy SEBAN <jeremy@seban.eu>
 
 WORKDIR /srv
-RUN wget http://download.dokuwiki.org/src/dokuwiki/dokuwiki-stable.tgz
+RUN apk add --update openssl
+RUN wget https://download.dokuwiki.org/src/dokuwiki/dokuwiki-stable.tgz
 RUN tar -xzf dokuwiki-stable.tgz
 RUN mv dokuwiki-2* /srv/dokuwiki
-RUN apk add --update apache2 php-apache2 php-xml
+RUN apk add --update apache2 php5-apache2 php5-xml
 RUN rm -rf /var/cache/apk/*
 RUN chown apache:apache -R /srv/dokuwiki
 RUN mkdir /run/apache2

--- a/README.md
+++ b/README.md
@@ -12,3 +12,15 @@ docker run -d -p 80:80 \
   -v /mnt/volumes/doku/data:/srv/dokuwiki/data \
   --name=dokuwiki bahaika/dokuwiki
 ```
+### Dokuwiki lighweight image
+
+![Dokuwiki logo](https://raw.githubusercontent.com/HipsterWhale/docker-dokuwiki/master/dokuwiki_logo.png)
+
+#### Usage
+
+```
+docker run -d -p 80:80 \
+  -v /mnt/volumes/doku/conf:/srv/dokuwiki/conf \
+  -v /mnt/volumes/doku/data:/srv/dokuwiki/data \
+  --name=dokuwiki bahaika/dokuwiki
+```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-This is a fork of MechanicalSloth/docker-dokuwiki - it uses a newer Alpine & Dokuwiki image.
-
 ### Dokuwiki lighweight image
 
 ![Dokuwiki logo](https://raw.githubusercontent.com/HipsterWhale/docker-dokuwiki/master/dokuwiki_logo.png)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+This is a fork of MechanicalSloth/docker-dokuwiki - it uses a newer Alpine & Dokuwiki image.
+
 ### Dokuwiki lighweight image
 
 ![Dokuwiki logo](https://raw.githubusercontent.com/HipsterWhale/docker-dokuwiki/master/dokuwiki_logo.png)

--- a/README.md
+++ b/README.md
@@ -10,15 +10,3 @@ docker run -d -p 80:80 \
   -v /mnt/volumes/doku/data:/srv/dokuwiki/data \
   --name=dokuwiki bahaika/dokuwiki
 ```
-### Dokuwiki lighweight image
-
-![Dokuwiki logo](https://raw.githubusercontent.com/HipsterWhale/docker-dokuwiki/master/dokuwiki_logo.png)
-
-#### Usage
-
-```
-docker run -d -p 80:80 \
-  -v /mnt/volumes/doku/conf:/srv/dokuwiki/conf \
-  -v /mnt/volumes/doku/data:/srv/dokuwiki/data \
-  --name=dokuwiki bahaika/dokuwiki
-```


### PR DESCRIPTION
Hi!

With this new Dockerfile, you can build with the latest stable Dokuwiki version (2017-02). 
The previous Dockerfile worked 2 years ago, but needed minor modifications.